### PR TITLE
Add type filtering and dedicated graph query

### DIFF
--- a/app/api/bookmarks/graph/route.ts
+++ b/app/api/bookmarks/graph/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getBookmarkGraph } from "@/server/bookmarks/queries";
+import { getGraphBookmarks } from "@/server/bookmarks/queries";
 import { getUser } from "@/lib/get-user";
 
 export async function GET(req: Request) {
@@ -9,14 +9,15 @@ export async function GET(req: Request) {
 
   const { searchParams } = new URL(req.url);
   const min = parseInt(searchParams.get("min") ?? "3", 10);
+  const type = searchParams.get("type") || undefined;
 
   try {
-    const data = await getBookmarkGraph(user.id, min);
+    const data = await getGraphBookmarks(user.id, min, type);
     return NextResponse.json(data);
   } catch (error) {
     console.log(error);
     return NextResponse.json(
-      { error: "Failed to fetch graph edges" },
+      { error: "Failed to fetch graph data" },
       { status: 500 },
     );
   }

--- a/app/api/bookmarks/route.ts
+++ b/app/api/bookmarks/route.ts
@@ -34,9 +34,10 @@ export async function GET(req: Request) {
   const groupId = searchParams.get("group") || undefined;
   const limit = searchParams.has("limit") ? Number(searchParams.get("limit")) : undefined;
   const offset = searchParams.has("offset") ? Number(searchParams.get("offset")) : undefined;
+  const type = searchParams.get("type") || undefined;
 
   try {
-    const { data, total } = await getBookmarksForUser(user.id, search, groupId, limit, offset);
+    const { data, total } = await getBookmarksForUser(user.id, search, groupId, limit, offset, type);
     return NextResponse.json({ data, total });
   } catch (error) {
     console.log(error);

--- a/app/components/TypeFilter.tsx
+++ b/app/components/TypeFilter.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+const TYPES = [
+  { label: "All", value: "" },
+  { label: "Twitter", value: "tweet" },
+  { label: "Links", value: "link" },
+  { label: "YouTube", value: "youtube" },
+] as const;
+
+export default function TypeFilter({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (type: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 px-6 pt-3">
+      {TYPES.map((t) => (
+        <button
+          key={t.value}
+          onClick={() => onChange(t.value)}
+          className={`px-3 py-1 text-xs font-medium rounded-full transition-colors ${
+            value === t.value
+              ? "bg-zinc-900 text-white"
+              : "text-zinc-400 hover:text-zinc-600"
+          }`}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/api/src/routes/bookmarks/index.ts
+++ b/packages/api/src/routes/bookmarks/index.ts
@@ -17,6 +17,7 @@ bookmarks.get("/", async (c) => {
   const groupId = c.req.query("group");
   const limit = parseInt(c.req.query("limit") ?? "100");
   const offset = parseInt(c.req.query("offset") ?? "0");
+  const type = c.req.query("type");
 
   try {
     const { data, total } = await getBookmarksForAPI(
@@ -25,6 +26,7 @@ bookmarks.get("/", async (c) => {
       groupId,
       limit,
       offset,
+      type,
     );
     return c.json({ data, meta: { total, limit, offset } });
   } catch (error) {

--- a/packages/cli/src/commands/bookmarks.ts
+++ b/packages/cli/src/commands/bookmarks.ts
@@ -9,6 +9,7 @@ export const registerBookmarksCommand = (program: Command) => {
     .option("-l, --limit <number>", "Max results", "20")
     .option("-o, --offset <number>", "Skip results")
     .option("-s, --search <string>", "Search bookmarks")
+    .option("-t, --type <string>", "Filter by type (tweet, link, youtube)")
     .option("-j, --json", "Output raw JSON")
     .description("List all bookmarks")
     .action(async (option) => {
@@ -16,6 +17,7 @@ export const registerBookmarksCommand = (program: Command) => {
       if (option.limit) searchParams.append("limit", String(parseInt(option.limit, 10)));
       if (option.offset) searchParams.append("offset", String(parseInt(option.offset, 10)));
       if (option.search) searchParams.append("search", option.search);
+      if (option.type) searchParams.append("type", option.type);
       const result = await apiRequest(
         `bookmarks?${searchParams.toString()}`,
         "GET",


### PR DESCRIPTION
## Summary
- Add type filter chips (All | Twitter | Links | YouTube) to the library view, working in both grid and graph modes
- Create dedicated `getGraphBookmarks()` SQL query that loads ALL bookmarks + edges in a single request — graph view no longer piggybacks on the paginated `useBookmarks` query (50 items/page)
- Add `--type` flag to CLI `bookmarks list` command

## Test plan
- [ ] Grid view: click each filter chip, verify bookmarks filter correctly
- [ ] Graph view: switch to graph, verify it loads all connected bookmarks (not just first 50)
- [ ] Graph view: verify type filters work in graph mode
- [ ] CLI: `scx bookmarks list --type tweet` returns only tweets
- [ ] `pnpm build` passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/supacortex/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
