### PR TITLE
Fix tsquery special char crashes and count type

### DIFF
--- a/server/bookmarks/queries.ts
+++ b/server/bookmarks/queries.ts
@@ -122,16 +122,18 @@ export const getBookmarksForUser = async (
   if (search) {
     // Split into words, strip special chars, append :* for prefix matching, join with | (OR)
     // ts_rank handles relevance — more term matches = higher score
-    const prefixQuery = search
+    const words = search
       .trim()
       .split(/\s+/)
       .filter(Boolean)
-      .map((word) => word.replace(/[^a-zA-Z0-9]/g, ""))
-      .filter(Boolean)
-      .map((word) => `${word}:*`)
-      .join(" | ");
-    tsQuery = sql`to_tsquery('english', ${prefixQuery})`;
-    conditions.push(sql`${bookmarks.searchVector} @@ ${tsQuery}`);
+      .map((word) => word.replace(/[^\p{L}\p{N}]/gu, ""))
+      .filter(Boolean);
+
+    if (words.length > 0) {
+      const prefixQuery = words.map((word) => `${word}:*`).join(" | ");
+      tsQuery = sql`to_tsquery('english', ${prefixQuery})`;
+      conditions.push(sql`${bookmarks.searchVector} @@ ${tsQuery}`);
+    }
   }
 
   // When filtering by group, only return bookmarks in that group
@@ -223,16 +225,18 @@ export const getBookmarksForAPI = async (
   }
 
   if (search) {
-    const prefixQuery = search
+    const words = search
       .trim()
       .split(/\s+/)
       .filter(Boolean)
-      .map((word) => word.replace(/[^a-zA-Z0-9]/g, ""))
-      .filter(Boolean)
-      .map((word) => `${word}:*`)
-      .join(" | ");
-    tsQuery = sql`to_tsquery('english', ${prefixQuery})`;
-    conditions.push(sql`${bookmarks.searchVector} @@ ${tsQuery}`);
+      .map((word) => word.replace(/[^\p{L}\p{N}]/gu, ""))
+      .filter(Boolean);
+
+    if (words.length > 0) {
+      const prefixQuery = words.map((word) => `${word}:*`).join(" | ");
+      tsQuery = sql`to_tsquery('english', ${prefixQuery})`;
+      conditions.push(sql`${bookmarks.searchVector} @@ ${tsQuery}`);
+    }
   }
 
   if (groupId) {

--- a/server/memory/queries.ts
+++ b/server/memory/queries.ts
@@ -16,17 +16,18 @@ export const getMemoryForUser = async (
   let tsQuery;
 
   if (searchQuery) {
-    const prefixQuery = searchQuery
+    const words = searchQuery
       .trim()
       .split(/\s+/)
       .filter(Boolean)
-      .map((word) => word.replace(/[^a-zA-Z0-9]/g, ""))
-      .filter(Boolean)
-      .map((word) => `${word}:*`)
-      .join("|");
+      .map((word) => word.replace(/[^\p{L}\p{N}]/gu, ""))
+      .filter(Boolean);
 
-    tsQuery = sql`to_tsquery('english', ${prefixQuery})`;
-    conditions.push(sql`${memory.searchVector} @@ ${tsQuery}`);
+    if (words.length > 0) {
+      const prefixQuery = words.map((word) => `${word}:*`).join("|");
+      tsQuery = sql`to_tsquery('english', ${prefixQuery})`;
+      conditions.push(sql`${memory.searchVector} @@ ${tsQuery}`);
+    }
   }
 
   const where = and(...conditions);


### PR DESCRIPTION
## Summary
- Strip non-alphanumeric chars from search words before building tsquery (prevents Postgres syntax errors on input like `don't`, `C++`, etc.)
- Cast `count(*)` to `::int` so the API returns a number instead of a string

Both fixes applied across bookmarks and memory queries.

Closes #46

## Test plan
- [ ] Search for `don't` — should return results without crashing
- [ ] Search for `C++` — should work
- [ ] Verify `meta.count` / `meta.total` in API responses is a number, not a string

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/supacortex/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
