### PR TITLE
Fix sidebar conversation opening in all empty panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 /.claude/worktrees
+vision.md

--- a/app/components/ChatPanel.tsx
+++ b/app/components/ChatPanel.tsx
@@ -174,13 +174,11 @@ export function ChatPanel({
   conversationId,
   widthClass,
   onConversationCreated,
-  highlighted,
 }: {
   panelId: string;
   conversationId: string | null;
   widthClass: string;
   onConversationCreated: (panelId: string, newConversationId: string) => void;
-  highlighted?: boolean;
 }) {
   const ctx = useChatPanelContext();
   const chatPanelRef = useRef<HTMLElement>(null);
@@ -530,7 +528,7 @@ export function ChatPanel({
       key={panelId}
       id={`panel-${panelId}`}
       data-chat-links
-      className={`relative h-full ${widthClass} shadow-card rounded-xl mx-2 overflow-hidden flex flex-col transition-colors ${highlighted ? "bg-blue-50" : "bg-white"}`}
+      className={`relative h-full ${widthClass} bg-white shadow-card rounded-xl mx-2 overflow-hidden flex flex-col`}
     >
       <ChatLinkInterceptor
         containerRef={chatPanelRef}


### PR DESCRIPTION
## Summary
- Fix bug where selecting a conversation from the sidebar would open it in **all** empty chat panels instead of just one
- Root cause: the URL seed effect stayed armed when the page loaded without `?id=`, so when `handleConversationSelect` later called `router.replace`, the seed effect fired and assigned the conversation to the second empty panel
- Fix: capture the initial URL value at mount time via `useRef` so later sidebar-driven URL changes are ignored
- Also moves panel highlight styling from ChatPanel body to the tab bar, and adds `vision.md` to `.gitignore`

## Test plan
- [ ] Open the app with 2+ empty chat panels
- [ ] Click a conversation in the sidebar — should only open in one panel
- [ ] Refresh with `?id=<conversationId>` — should still seed into one panel correctly

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/supacortex/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
