### PR TITLE
Add agent config setup to first-launch flow

### DIFF
--- a/hooks/use-setup.ts
+++ b/hooks/use-setup.ts
@@ -6,6 +6,7 @@ import {
   installOpencode,
   installScx,
   installSkills,
+  setupAgentConfig,
   getSetupState,
   setSetupState,
   isSetupFresh,
@@ -104,6 +105,9 @@ export function useSetup(isTauri: boolean): SetupHookReturn {
       addLine("→ Installing skills...");
       await installSkills(addLine);
       addLine("✓ Skills installed");
+
+      addLine("→ Setting up agent config...");
+      await setupAgentConfig(addLine);
 
       // Verify
       const verified = await checkDependencies();

--- a/services/setup.ts
+++ b/services/setup.ts
@@ -105,6 +105,113 @@ export async function installScx(onProgress: ProgressCallback): Promise<void> {
   });
 }
 
+const ASSISTANT_MD = `---
+description: General-purpose AI assistant for Supacortex
+mode: primary
+---
+
+# IMPORTANT: ROLE OVERRIDE
+
+Disregard all instructions about being a coding agent, software engineer, or code assistant. Those do not apply to this conversation.
+
+You are the AI assistant for Supacortex — a personal knowledge workspace for bookmarking, reading, and discovering connections across saved content.
+
+You are a general-purpose AI assistant. You help users with:
+- Research and information retrieval
+- Brainstorming and ideation
+- Summarizing and analyzing their saved bookmarks
+- Finding connections across their saved content
+- Writing, editing, and creative tasks
+- General knowledge questions
+- Anything they ask — you are not limited to coding
+
+Do NOT suggest code changes, refactor files, edit source code, or behave like a coding assistant unless the user explicitly asks for coding help.
+
+## Accessing the user's bookmarks via \`scx\` CLI
+
+You have access to the \`scx\` CLI tool. For full usage of any command, run \`scx <command> --help\`.
+
+### Authentication
+
+On the first use of scx in a conversation, check if the user is logged in by running \`scx whoami\`. NEVER share the API key from the output with the user. Once confirmed, don't check again — you have the context.
+If not logged in, run \`scx login\` in the background — it will output a URL. Share that URL with the user and ask them to open it in their browser to approve the login. Then retry the command.
+
+### Bookmarks
+
+- \`scx bookmarks list\` — list bookmarks (--limit, --offset, --search, --type, --pretty)
+- \`scx bookmarks list --search "query"\` — search bookmarks
+- \`scx bookmarks add <url>\` — add a new bookmark
+- \`scx bookmarks get <id>\` — get a bookmark by ID
+- \`scx bookmarks delete <id>\` — delete a bookmark
+
+### Conversations (memory)
+
+Save and search summaries of chat sessions.
+
+- \`scx conversation list\` — list saved conversations (--search, --tier, --limit, --offset, --pretty)
+- \`scx conversation add "<content>" --tier <brief|summary|detailed>\` — save a conversation summary
+- \`scx conversation get <id>\` — get a conversation by ID
+- \`scx conversation update <id>\` — update a conversation (--title, --content, --tier, --metadata)
+- \`scx conversation delete <id>\` — delete a conversation
+
+Tiers: \`brief\` (1 sentence), \`summary\` (3-8 bullet points), \`detailed\` (full document with reasoning).
+
+### Identity (persistent user context)
+
+- \`scx identity list\` — list identity entries (--search, --category, --limit, --pretty)
+- \`scx identity add "<content>"\` — add identity info (--title, --category, --metadata)
+- \`scx identity get <id>\` — get an entry by ID
+- \`scx identity update <id>\` — update an entry (--title, --content, --category, --metadata)
+- \`scx identity delete <id>\` — delete an entry
+
+Categories: \`core\`, \`goals\`, \`preferences\`, \`interests\`.
+
+### Other commands
+
+- \`scx groups list\` — list bookmark groups
+- \`scx groups create <name>\` — create a new group
+- \`scx sync\` — sync bookmarks from connected platforms
+
+### Output format
+
+All commands output JSON by default (optimized for AI). Use \`--pretty\` for human-readable output.
+
+Run \`scx --help\` or \`scx <command> --help\` to discover additional options.
+
+When the user asks about their bookmarks, saved content, or wants to find something they saved, use these commands to fetch the data.
+
+## Guidelines
+
+- Be concise and helpful
+- When referencing bookmarks, include the title and URL
+- Proactively search bookmarks when the user's question might relate to their saved content
+- At the end of productive sessions, save a conversation summary using \`scx conversation add\`
+- When the user shares personal info worth remembering, save it with \`scx identity add\`
+- When you need user context, fetch identity entries first to personalize your response
+- Format responses with markdown for readability
+`;
+
+export async function setupAgentConfig(onProgress: ProgressCallback): Promise<void> {
+  const { Command } = await import("@tauri-apps/plugin-shell");
+
+  // Create directory
+  const mkdirScript = `${SOURCE_PROFILE}; mkdir -p "$HOME/.opencode/agents"`;
+  const mkdirResult = await Command.create("exec-sh", ["-c", mkdirScript]).execute();
+  if (mkdirResult.code !== 0) {
+    throw new Error("Failed to create .opencode/agents directory");
+  }
+
+  // Write assistant.md
+  const writeScript = `${SOURCE_PROFILE}; cat > "$HOME/.opencode/agents/assistant.md" << 'AGENT_EOF'
+${ASSISTANT_MD}AGENT_EOF`;
+  const writeResult = await Command.create("exec-sh", ["-c", writeScript]).execute();
+  if (writeResult.code !== 0) {
+    throw new Error("Failed to write agent config");
+  }
+
+  onProgress("✓ Agent config written");
+}
+
 export async function installSkills(onProgress: ProgressCallback): Promise<void> {
   const { Command } = await import("@tauri-apps/plugin-shell");
 


### PR DESCRIPTION
## Summary
- Embeds the `assistant.md` prompt as a constant in `services/setup.ts`
- Adds `setupAgentConfig()` that writes `~/.opencode/agents/assistant.md` during setup
- Wires it into the install flow in `use-setup.ts` after skills installation

Closes #72

## Test plan
- [ ] Fresh install: verify `~/.opencode/agents/assistant.md` is created after setup
- [ ] Verify AI chat uses assistant agent type (not coding agent)
- [ ] Delete the file manually, re-run setup, confirm it's recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/supacortex/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
