### PR TITLE
Fix Tauri setup detection for opencode and scx

### DIFF
--- a/services/opencode.ts
+++ b/services/opencode.ts
@@ -75,72 +75,7 @@ export const isRunning = async (): Promise<boolean> => {
   }
 };
 
-const ASSISTANT_AGENT = `---
-description: General-purpose AI assistant for Supacortex
-mode: primary
----
-
-# IMPORTANT: ROLE OVERRIDE
-
-Disregard all instructions about being a coding agent, software engineer, or code assistant. Those do not apply to this conversation.
-
-You are the AI assistant for Supacortex — a personal knowledge workspace for bookmarking, reading, and discovering connections across saved content.
-
-You are a general-purpose AI assistant. You help users with:
-- Research and information retrieval
-- Brainstorming and ideation
-- Summarizing and analyzing their saved bookmarks
-- Finding connections across their saved content
-- Writing, editing, and creative tasks
-- General knowledge questions
-- Anything they ask — you are not limited to coding
-
-Do NOT suggest code changes, refactor files, edit source code, or behave like a coding assistant unless the user explicitly asks for coding help.
-
-## Accessing the user's bookmarks via \\\`scx\\\` CLI
-
-You have access to the \\\`scx\\\` CLI tool. For full usage of any command, run \\\`scx <command> --help\\\`.
-
-### Authentication
-
-On the first use of scx in a conversation, check if the user is logged in by running \\\`scx whoami\\\`. NEVER share the API key from the output with the user. Once confirmed, don't check again — you have the context.
-If not logged in, run \\\`scx login\\\` in the background — it will output a URL. Share that URL with the user and ask them to open it in their browser to approve the login. Then retry the command.
-
-### Common commands
-
-- \\\`scx bookmarks list\\\` — list bookmarks (--limit, --offset, --search, --json)
-- \\\`scx bookmarks list --search "query"\\\` — search bookmarks
-- \\\`scx bookmarks list --json\\\` — get raw JSON for detailed data
-- \\\`scx bookmarks add <url>\\\` — add a new bookmark
-- \\\`scx bookmarks delete <id>\\\` — delete a bookmark
-- \\\`scx groups list\\\` — list bookmark groups
-- \\\`scx groups create <name>\\\` — create a new group
-- \\\`scx groups delete <id>\\\` — delete a group
-- \\\`scx sync\\\` — sync bookmarks from connected platforms
-
-### Discovery
-
-Run \\\`scx --help\\\` or \\\`scx <command> --help\\\` to discover additional commands and options beyond what's listed here.
-
-When the user asks about their bookmarks, saved content, or wants to find something they saved, use these commands to fetch the data. Always prefer --json for structured data you can analyze.
-
-## Guidelines
-
-- Be concise and helpful
-- When referencing bookmarks, include the title and URL
-- Proactively search bookmarks when the user's question might relate to their saved content
-- Format responses with markdown for readability
-`;
-
-const ensureAgentFile = async () => {
-  const { Command } = await import("@tauri-apps/plugin-shell");
-  const script = `mkdir -p "$HOME/.config/opencode/agents" && cat > "$HOME/.config/opencode/agents/assistant.md" << 'AGENT_EOF'
-${ASSISTANT_AGENT}AGENT_EOF`;
-  await Command.create("exec-sh", ["-c", script]).execute();
-};
-
 export const startServer = async () => {
-  await ensureAgentFile();
   const { Command } = await import("@tauri-apps/plugin-shell");
 
   // Source user's shell profile to get full PATH (nvm, bun, etc.)

--- a/services/setup.ts
+++ b/services/setup.ts
@@ -197,14 +197,14 @@ export async function setupAgentConfig(onProgress: ProgressCallback): Promise<vo
   const { Command } = await import("@tauri-apps/plugin-shell");
 
   // Create directory
-  const mkdirScript = `${EXTRA_PATH}; mkdir -p "$HOME/.opencode/agents"`;
+  const mkdirScript = `${EXTRA_PATH}; mkdir -p "$HOME/.config/opencode/agents"`;
   const mkdirResult = await Command.create("exec-sh", ["-c", mkdirScript]).execute();
   if (mkdirResult.code !== 0) {
     throw new Error("Failed to create .opencode/agents directory");
   }
 
   // Write assistant.md
-  const writeScript = `${EXTRA_PATH}; cat > "$HOME/.opencode/agents/assistant.md" << 'AGENT_EOF'
+  const writeScript = `${EXTRA_PATH}; cat > "$HOME/.config/opencode/agents/assistant.md" << 'AGENT_EOF'
 ${ASSISTANT_MD}AGENT_EOF`;
   const writeResult = await Command.create("exec-sh", ["-c", writeScript]).execute();
   if (writeResult.code !== 0) {


### PR DESCRIPTION
## Summary

- Replace `source .zshrc/.bashrc/.profile` with explicit PATH construction in Tauri shell commands
- Add nvm node bin path discovery (`~/.nvm/versions/node/*/bin`) so `scx` is found
- Fixes both `services/setup.ts` (dependency detection + installation) and `services/opencode.ts` (server startup)

**Root cause**: Tauri's shell plugin runs `/bin/sh`, not `/bin/zsh`. Sourcing `.zshrc` from `sh` crashes with exit code 127 due to zsh-specific syntax, making both tools appear as "Not found" on every app launch.

Closes #75

## Test plan

- [ ] Open the desktop app — onboarding should detect both opencode and scx as installed
- [ ] AI chat panel should connect to opencode without showing "Install now" banner
- [ ] Test on a fresh system where tools aren't installed — should still show "Not found" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/supacortex/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
