### PR TITLE
Fix scx detection and chat banner when opencode installed

### DIFF
--- a/app/(dashboard)/app/page.tsx
+++ b/app/(dashboard)/app/page.tsx
@@ -588,7 +588,7 @@ function ChatPageContent() {
     onOpenBrowser: handleOpenBrowser,
     onOpenReader: handleOpenReader,
     onOpenInNewPanel: handleOpenInNewPanel,
-    setupSkipped: setup.phase === "skipped",
+    setupSkipped: setup.phase === "skipped" && !setup.dependencies?.opencode,
     onTriggerSetup: setup.retry,
   }), [
     connected, connecting, connectionError, isTauri,
@@ -597,7 +597,7 @@ function ChatPageContent() {
     createSession, refetchSessions,
     providers, defaultModel,
     handleOpenBrowser, handleOpenReader, handleOpenInNewPanel,
-    setup.phase, setup.retry,
+    setup.phase, setup.retry, setup.dependencies,
   ]);
 
   const renderPanel = (panel: PanelConfig) => {

--- a/services/opencode.ts
+++ b/services/opencode.ts
@@ -82,7 +82,7 @@ export const startServer = async () => {
   // macOS apps launched from Finder don't inherit shell env
   const command = Command.create("exec-sh", [
     "-c",
-    `NVM_BIN=$(ls -d $HOME/.nvm/versions/node/*/bin 2>/dev/null | head -1); export PATH="$HOME/.opencode/bin:$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin\${NVM_BIN:+:\$NVM_BIN}:$PATH" && cd "$HOME" && opencode serve --port ${PORT}`,
+    `NVM_BINS=$(ls -d $HOME/.nvm/versions/node/*/bin 2>/dev/null | tr '\\n' ':'); export PATH="$HOME/.opencode/bin:$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:\${NVM_BINS}$PATH" && cd "$HOME" && opencode serve --port ${PORT}`,
   ]);
 
   let startupError = "";

--- a/services/setup.ts
+++ b/services/setup.ts
@@ -6,7 +6,7 @@ const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 // Build PATH with common binary directories.
 // We can't source .zshrc/.bashrc because Tauri's shell plugin runs /bin/sh,
 // and zsh-specific syntax in those files causes sh to crash (exit 127).
-const EXTRA_PATH = `NVM_BIN=$(ls -d $HOME/.nvm/versions/node/*/bin 2>/dev/null | head -1); export PATH="$HOME/.opencode/bin:$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin\${NVM_BIN:+:\$NVM_BIN}:$PATH"`;
+const EXTRA_PATH = `NVM_BINS=$(ls -d $HOME/.nvm/versions/node/*/bin 2>/dev/null | tr '\\n' ':'); export PATH="$HOME/.opencode/bin:$HOME/.bun/bin:$HOME/.local/bin:/usr/local/bin:\${NVM_BINS}$PATH"`;
 
 interface SetupState {
   setupComplete: boolean;


### PR DESCRIPTION
## Summary

Follow-up to #76. Two issues:

- **scx not detected**: `head -1` picked the oldest nvm node version (`v20.17.0`) which doesn't have scx. Now adds ALL nvm bin dirs to PATH
- **Chat banner wrong**: "AI chat requires opencode" showed even when opencode was installed but scx wasn't. Chat only needs opencode — now only shows banner when opencode is actually missing

## Test plan

- [ ] Onboarding detects both opencode and scx
- [ ] Chat panel works when opencode is installed, even if scx isn't
- [ ] Skipping setup when only scx is missing still allows chat to function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/monorepo-labs/supacortex/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
